### PR TITLE
Fixed a problem with stomp_write

### DIFF
--- a/src/stomp.c
+++ b/src/stomp.c
@@ -339,7 +339,7 @@ APR_DECLARE(apr_status_t) stomp_write(stomp_connection *connection, stomp_frame 
    // Write the body.
    if( frame->body != NULL ) {
       int body_length = frame->body_length;
-	  if(body_length < 0)
+	  if(body_length <= 0)
 		  body_length = strlen(frame->body);
       rc = stomp_write_buffer(connection, frame->body, body_length);
       CHECK_SUCCESS;

--- a/src/stomp.c
+++ b/src/stomp.c
@@ -319,12 +319,15 @@ APR_DECLARE(apr_status_t) stomp_write(stomp_connection *connection, stomp_frame 
 	  if(frame->body_length >= 0) {
 		  apr_pool_t *length_pool;
 		  char *length_string;
-
+   
 		  apr_pool_create(&length_pool, pool);
 		  rc = stomp_write_buffer(connection, "content-length:", 15);
 		  CHECK_SUCCESS;
 		  
-		  length_string = apr_itoa(length_pool, frame->body_length);
+          int body_length = frame->body_length;
+          if (body_length <= 0)
+              body_length = strlen(frame->body) +1;
+		  length_string = apr_itoa(length_pool, body_length);
 		  rc = stomp_write_buffer(connection, length_string, strlen(length_string));
 		  CHECK_SUCCESS;
 		  rc = stomp_write_buffer(connection, "\n", 1);
@@ -338,11 +341,11 @@ APR_DECLARE(apr_status_t) stomp_write(stomp_connection *connection, stomp_frame 
    
    // Write the body.
    if( frame->body != NULL ) {
-      int body_length = frame->body_length;
-	  if(body_length <= 0)
-		  body_length = strlen(frame->body);
-      rc = stomp_write_buffer(connection, frame->body, body_length);
-      CHECK_SUCCESS;
+        int body_length = frame->body_length;
+        if(body_length <= 0)
+            body_length = strlen(frame->body) + 1;
+        rc = stomp_write_buffer(connection, frame->body, body_length);
+        CHECK_SUCCESS;
    }
    rc = stomp_write_buffer(connection, "\0\n", 2);
    CHECK_SUCCESS;


### PR DESCRIPTION
Previously when writing a message with a body I had to set frame.body_length = strlen(frame.body) on my own. The changes I made should allow stomp_write to set that instead so the coder doesn't have to worry about the body_length.
