### PR TITLE
64bit regression fixed, and applied apr CFLAGS to stomp example

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.68])
+AC_PREREQ([2.60])
 AC_INIT([libstomp], 0.1.0, a3linux@gmail.com)
 AM_INIT_AUTOMAKE(libstomp, 0.1.0)
 AC_PROG_LIBTOOL

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AC_CONFIG_HEADERS([config.h])
 
 # Checks for programs.
 AC_PROG_CC
+AM_PROG_CC_C_O
 PKG_CHECK_MODULES([APR],[apr-1])
 
 # Checks for header files.

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -1,4 +1,4 @@
 bin_PROGRAMS = stomptest
-stomptest_CFLAGS = -I ../src
+stomptest_CFLAGS = -I ../src @APR_CFLAGS@
 stomptest_LDADD = ../src/libstomp.la
 stomptest_SOURCES = main.c

--- a/src/stomp.c
+++ b/src/stomp.c
@@ -418,7 +418,7 @@ APR_DECLARE(apr_status_t) stomp_read(stomp_connection *connection, stomp_frame *
 			  char endbuffer[2];
 			  apr_size_t length = 2;
 
-			  f->body_length = atoi(content_length);
+			  f->body_length = apr_atoi64(content_length);
 			  f->body = apr_pcalloc(pool, f->body_length);
 			  rc = apr_socket_recv(connection->socket, f->body, &f->body_length);
 			  CHECK_SUCCESS;

--- a/src/stomp.c
+++ b/src/stomp.c
@@ -17,10 +17,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#if defined(__i386__)
-#include <unistd.h>
-typedef off_t off64_t;
-#endif
 #include <apr-1/apr.h>
 #include <apr-1/apr_strings.h>
 #include "stomp.h"

--- a/src/stomp.h
+++ b/src/stomp.h
@@ -37,7 +37,7 @@ typedef struct stomp_frame {
    char *command;
    apr_hash_t *headers;
    char *body;
-   apr_int64_t body_length;
+   apr_size_t body_length;
 } stomp_frame;
 
 

--- a/src/stomp.h
+++ b/src/stomp.h
@@ -37,7 +37,7 @@ typedef struct stomp_frame {
    char *command;
    apr_hash_t *headers;
    char *body;
-   long body_length;
+   apr_int64_t body_length;
 } stomp_frame;
 
 


### PR DESCRIPTION
These changes enable and has been tested with stomp endpoint of activemq 
example run:

    Connecting......OK
    Sending connect message.OK
    Reading Response.Response: CONNECTED, 
    OK
    Sending Subscribe.OK
    Sending Message.OK
    Reading Response.Response: MESSAGE, This is the message
    OK
    Sending Disconnect.OK
    Disconnecting...OK
